### PR TITLE
Add tests for cookiecutter template generation

### DIFF
--- a/.github/workflows/generate-templates.yaml
+++ b/.github/workflows/generate-templates.yaml
@@ -16,4 +16,4 @@ jobs:
         with:
           miniconda-version: "latest"
       - run: pip install cookiecutter pre-commit pytest pytest-order
-      - run: pytest -m "not python_env"
+      - run: pytest -m "default"

--- a/.github/workflows/generate-templates.yaml
+++ b/.github/workflows/generate-templates.yaml
@@ -1,0 +1,19 @@
+name: Generate templates and lint results
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  templating:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: "latest"
+      - run: pip install cookiecutter pre-commit pytest pytest-order
+      - run: pytest -m "not python_env"

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Templates are divided into two categories: single and stack. Single templates ar
 
 ## Testing
 
-Test are written in with `pytest`. Since some tests will create Python environments, it es a good idea to run them in Docker container. To run the tests, `cd` into `tests` and run, e.g.,:
+Tests are written with `pytest`. Since some tests will create Python environments, it is a good idea to run them in a Docker container. To run the tests, `cd` into `tests` and run, e.g.,:
 
 ```
 docker compose up test-default
 ```
 
-The default test-set includes template creation with default values and a pre-commit linting check on the created repos.
+The default test-set includes template creation with default values and a pre-commit linting check on the created repos. They use `@pytest.mark.default` and are also run in GitHub's CI.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # pre-committed
 
-Collection of dev environment setups with basic pre-commit/linting configs. Contains advanced options such as environment creation in Python. Win/Mac/Linux.
+Collection of dev environment setups with basic pre-commit/linting configs. Contains advanced options such as:
+
+- OS recognition and compatibility (Mac, Linux, Windows)
+- Language specific .gitignore creation with API call to [gitignore.io](https://www.toptal.com/developers/gitignore)
+- Python environment creation for venv, conda, mamba
+- Git init
 
 Install [cookiecutter](https://github.com/cookiecutter/cookiecutter) in your Python environment or with your package manager of choice, e.g., with `pip install cookiecutter` or `brew install cookiecutter`.
 
@@ -36,3 +41,13 @@ Templates are divided into two categories: single and stack. Single templates ar
     ├── python-django_usecase1/
     └── ...
 ```
+
+## Testing
+
+Test are written in with `pytest`. Since some tests will create Python environments, it es a good idea to run them in Docker container. To run the tests, `cd` into `tests` and run, e.g.,:
+
+```
+docker compose up test-default
+```
+
+The default test-set includes template creation with default values and a pre-commit linting check on the created repos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,8 @@ extend-select = [
   # "FURB",        # refurb
   # "PYI",         # flake8-pyi
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "python_env: [slow] Pythen venv/conda/mamba environment generation",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,6 @@ extend-select = [
 
 [tool.pytest.ini_options]
 markers = [
+    "default: [fast] Default tests; run in CI",
     "python_env: [slow] Pythen venv/conda/mamba environment generation",
 ]

--- a/templates-single/python/hooks/post_gen_project.py
+++ b/templates-single/python/hooks/post_gen_project.py
@@ -85,16 +85,12 @@ def create_virtual_environment(package_manager: str):
         subprocess.run(["python", "-m", "venv", "env"])
 
         if os.name == "posix":  # Unix-like systems
+            subprocess.run(["env/bin/pip", "install", "--upgrade", "pip"], check=True)
             subprocess.run(
-                ["sh", "-c", "source env/bin/activate && pip install --upgrade pip"], check=True
-            )
-            subprocess.run(
-                ["sh", "-c", "source env/bin/activate && pip install -r requirements.txt"],
+                ["env/bin/pip", "install", "-r", "requirements.txt"],
                 check=True,
             )
-            subprocess.run(
-                ["sh", "-c", "source env/bin/activate && pre-commit install"], check=True
-            )
+            subprocess.run(["env/bin/pre-commit", "install"], check=True)
         elif os.name == "nt":  # Windows
             subprocess.run(
                 [".\\env\\Scripts\\python.exe", "-m", "pip", "install", "--upgrade", "pip"],

--- a/templates-single/python/{{cookiecutter.repo_name}}/environment.yaml
+++ b/templates-single/python/{{cookiecutter.repo_name}}/environment.yaml
@@ -1,8 +1,8 @@
 name: "{{cookiecutter.repo_name}}"
 channels:
-{% if cookiecutter.python_env == "conda" -%}
+{%- if cookiecutter.python_env == "conda" +%}
   - defaults
-{% endif -%}
+{%- endif +%}
   - conda-forge
 dependencies:
   - python==3.11

--- a/templates-single/python_datascience/hooks/post_gen_project.py
+++ b/templates-single/python_datascience/hooks/post_gen_project.py
@@ -92,16 +92,12 @@ def create_virtual_environment(package_manager: str):
         subprocess.run(["python", "-m", "venv", "env"])
 
         if os.name == "posix":  # Unix-like systems
+            subprocess.run(["env/bin/pip", "install", "--upgrade", "pip"], check=True)
             subprocess.run(
-                ["sh", "-c", "source env/bin/activate && pip install --upgrade pip"], check=True
-            )
-            subprocess.run(
-                ["sh", "-c", "source env/bin/activate && pip install -r requirements.txt"],
+                ["env/bin/pip", "install", "-r", "requirements.txt"],
                 check=True,
             )
-            subprocess.run(
-                ["sh", "-c", "source env/bin/activate && pre-commit install"], check=True
-            )
+            subprocess.run(["env/bin/pre-commit", "install"], check=True)
         elif os.name == "nt":  # Windows
             subprocess.run(
                 [".\\env\\Scripts\\python.exe", "-m", "pip", "install", "--upgrade", "pip"],

--- a/templates-single/python_datascience/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/templates-single/python_datascience/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: check-added-large-files
         args:
-          - '--maxkb=10000'
+          - "--maxkb=10000"
       - id: check-yaml
       - id: check-json
       - id: check-toml
@@ -18,7 +18,7 @@ repos:
       - id: requirements-txt-fixer
       - id: detect-aws-credentials
         args:
-            - '--allow-missing-credentials'
+          - "--allow-missing-credentials"
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:

--- a/templates-single/python_datascience/{{cookiecutter.repo_name}}/environment.yaml
+++ b/templates-single/python_datascience/{{cookiecutter.repo_name}}/environment.yaml
@@ -1,8 +1,8 @@
 name: "{{cookiecutter.repo_name}}"
 channels:
-{% if cookiecutter.python_env == "conda" -%}
+{%- if cookiecutter.python_env == "conda" +%}
   - defaults
-{% endif -%}
+{%- endif +%}
   - conda-forge
 dependencies:
   - python==3.11

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,4 +6,4 @@ ADD . /app
 
 RUN pip install cookiecutter pre-commit pytest pytest-order
 
-CMD [ "pytest", "-m", "not python_env" ]
+CMD [ "pytest", "-m", "default" ]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,9 @@
+FROM continuumio/miniconda3
+
+WORKDIR /app
+
+ADD . /app
+
+RUN pip install cookiecutter pre-commit pytest pytest-order
+
+CMD [ "pytest", "-m", "not python_env" ]

--- a/tests/Dockerfile.mamba
+++ b/tests/Dockerfile.mamba
@@ -1,0 +1,11 @@
+FROM continuumio/miniconda3
+
+RUN conda install mamba -c conda-forge -y
+
+WORKDIR /app
+
+ADD . /app
+
+RUN pip install cookiecutter pre-commit pytest pytest-order
+
+CMD [ "pytest", "-m", "python_env"]

--- a/tests/cookiecutter_generation_specific_test.py
+++ b/tests/cookiecutter_generation_specific_test.py
@@ -1,0 +1,47 @@
+# All test which use not the default values
+import pytest
+
+from .cookiecutter_generation_test import generate_template as generate_specific_template
+
+
+def test_default_template():
+    git_init = {"git_init": "true"}
+    generate_specific_template("default_template", git_init)
+
+
+def test_python_env_files():
+    PATH = "templates-single/python"
+    use_venv = {"python_env": "venv", "create_python_env": "false"}
+    use_conda = {"python_env": "conda", "create_python_env": "false"}
+    generate_specific_template(PATH, use_venv)
+    generate_specific_template(PATH, use_conda)
+
+    PATH = "templates-single/python_datascience"
+    use_venv = {"python_env": "venv", "create_python_env": "false"}
+    use_conda = {"python_env": "conda", "create_python_env": "false"}
+    generate_specific_template(PATH, use_venv)
+    generate_specific_template(PATH, use_conda)
+
+
+@pytest.mark.python_env
+def test_python_template_envs():
+    PATH = "templates-single/python"
+    use_venv = {"python_env": "venv", "create_python_env": "true"}
+    use_conda = {"python_env": "conda", "create_python_env": "true"}
+    use_mamba = {"python_env": "mamba", "create_python_env": "true"}
+
+    generate_specific_template(PATH, use_venv)
+    generate_specific_template(PATH, use_conda)
+    generate_specific_template(PATH, use_mamba)
+
+
+@pytest.mark.python_env
+def test_python_datascience_template_envs():
+    PATH = "templates-single/python_datascience"
+    use_venv = {"python_env": "venv", "create_python_env": "true"}
+    use_conda = {"python_env": "conda", "create_python_env": "true"}
+    use_mamba = {"python_env": "mamba", "create_python_env": "true"}
+
+    generate_specific_template(PATH, use_venv)
+    generate_specific_template(PATH, use_conda)
+    generate_specific_template(PATH, use_mamba)

--- a/tests/cookiecutter_generation_specific_test.py
+++ b/tests/cookiecutter_generation_specific_test.py
@@ -4,11 +4,13 @@ import pytest
 from .cookiecutter_generation_test import generate_template as generate_specific_template
 
 
+@pytest.mark.default
 def test_default_template():
     git_init = {"git_init": "true"}
     generate_specific_template("default_template", git_init)
 
 
+@pytest.mark.default
 def test_python_env_files():
     PATH = "templates-single/python"
     use_venv = {"python_env": "venv", "create_python_env": "false"}

--- a/tests/cookiecutter_generation_test.py
+++ b/tests/cookiecutter_generation_test.py
@@ -1,0 +1,102 @@
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from cookiecutter.main import cookiecutter
+from jinja2 import Template
+
+TEST_OUTPUT_DIR = Path("test_output")
+
+
+@pytest.fixture(scope="module")
+def template_dirs():
+    return get_templates()
+
+
+def test_cookiecutter_json_exists(template_dirs):
+    for template_dir in template_dirs:
+        assert (
+            template_dir / "cookiecutter.json"
+        ).exists(), f"cookiecutter.json does not exist in {template_dir}"
+
+
+def test_generate_templates(template_dirs):
+    for template_dir in template_dirs:
+        generate_template(template_dir)
+
+
+@pytest.mark.order(-1)
+def test_linting_generated_templates():
+    generated_template_dirs = [
+        template_dir for template_dir in Path("test_output").glob("*/*") if template_dir.is_dir()
+    ]
+
+    for template_dir in generated_template_dirs:
+        pre_commit_config = template_dir / ".pre-commit-config.yaml"
+        if pre_commit_config.exists():
+            with subprocess.Popen(["bash"], stdin=subprocess.PIPE, cwd=template_dir) as proc:
+                proc.stdin.write(b"rm -rf .git/\n")
+                proc.stdin.write(b"git init -b main\n")
+                proc.stdin.write(b"pre-commit install --config .pre-commit-config.yaml\n")
+
+                if (template_dir / ".gitignore").exists():
+                    # API-generated .gitignore fails trailing-whitespace hook and is re-formatted
+                    # This should not fail the test
+                    proc.stdin.write(b"git add .gitignore\n")
+                    proc.stdin.write(b"pre-commit run --files .gitignore\n")
+
+                proc.stdin.write(b"git add .\n")
+                proc.stdin.write(b"pre-commit run --all-files\n")
+                proc.stdin.close()
+                proc.wait()
+                assert proc.returncode == 0, f"Linting failed for {template_dir}"
+
+
+def get_templates() -> list[Path]:
+    with open("cookiecutter.json") as f:
+        data = json.load(f)
+
+    templates = data["template"]
+    template_dirs = []
+
+    for template in templates:
+        template_path = template.split("(")[-1].split(")")[0]
+        template_dirs.append(Path(template_path))
+
+    return template_dirs
+
+
+def generate_template(template_dir: Path or str, custom_values: dict = None):
+    """Generate a template with cookiecutter and check if the project directory was created"""
+
+    template_dir = Path(template_dir) if isinstance(template_dir, str) else template_dir
+    custom_values_str = json.dumps(custom_values, sort_keys=True) + str(template_dir)
+    custom_values_hash = (
+        ("_" + hashlib.sha256(custom_values_str.encode()).hexdigest()[:8])
+        if custom_values is not None
+        else ""
+    )
+    output_dir = TEST_OUTPUT_DIR / template_dir.name
+
+    with open(template_dir / "cookiecutter.json") as f:
+        data = json.load(f)
+
+    repo_name_template = Template(data.get("repo_name"))
+    repo_name = f"{repo_name_template.render(cookiecutter=data)}{custom_values_hash}"
+
+    custom_values = custom_values or {}
+    custom_values.update({"repo_name": repo_name})
+
+    cookiecutter(
+        str(template_dir),
+        no_input=True,
+        output_dir=str(output_dir),
+        extra_context=custom_values,
+        overwrite_if_exists=True,
+    )
+
+    assert (
+        output_dir / repo_name
+    ).exists(), f"Project directory was not created for {template_dir}"

--- a/tests/cookiecutter_generation_test.py
+++ b/tests/cookiecutter_generation_test.py
@@ -15,6 +15,7 @@ def template_dirs():
     return get_templates()
 
 
+@pytest.mark.default
 def test_cookiecutter_json_exists(template_dirs):
     for template_dir in template_dirs:
         assert (
@@ -22,12 +23,14 @@ def test_cookiecutter_json_exists(template_dirs):
         ).exists(), f"cookiecutter.json does not exist in {template_dir}"
 
 
+@pytest.mark.default
 def test_generate_templates(template_dirs):
     for template_dir in template_dirs:
         generate_template(template_dir)
 
 
 @pytest.mark.order(-1)
+@pytest.mark.default
 def test_linting_generated_templates():
     generated_template_dirs = [
         template_dir for template_dir in Path("test_output").glob("*/*") if template_dir.is_dir()

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  test-default:
+    platform: linux/x86_64
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../:/app
+    working_dir: /app
+
+  test-python_envs:
+    platform: linux/x86_64
+    build:
+      context: .
+      dockerfile: Dockerfile.mamba
+    volumes:
+      - ../:/app
+    working_dir: /app


### PR DESCRIPTION
Adds tests for cookiecutter template generation:

- Tests cookiecutter template generation
- Tests pre-commit on generated repos if available
- Adds github workflow for those tests
- Defines additional tests for Python env creation
- Adds Docker testing setup for local testing